### PR TITLE
ci: update to iverilog 11.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Install simulators
-      run: sudo apt-get install iverilog verilator python3-pip
+      run: |
+        # TODO: Replace when iverilog is updated upstream
+        wget https://storage.googleapis.com/bluecmd/iverilog_11.0-0_amd64.deb
+        sudo apt-get install verilator python3-pip ./iverilog_11.0-0_amd64.deb
     - name: Install cocotb
       run: |
         pip3 install cocotb

--- a/README.md
+++ b/README.md
@@ -165,10 +165,11 @@ Finally review any changes to the \*.tcl files and commit them if they look reas
 To run the tests first install the dependencies:
 
 ```
-$ sudo apt install iverilog gtkwave verilator myhdl-cosimulation python3-myhdl
-$ cd /usr/share/myhdl/cosimulation/icarus
-$ sudo make
-$ sudo cp myhdl.vpi /usr/lib/x86_64-linux-gnu/ivl/
+# NOTE: You need Icarus Verilog 11.0 or newer, or always_* constructs will
+# not be accepted.
+$ sudo apt install iverilog gtkwave verilator
+$ sudo apt install python3-pip
+$ pip3 install cocotb
 ```
 
 Then to execute all tests run:


### PR DESCRIPTION
This is needed in order to switch to always_* constructs.