### PR TITLE
pcie-hip: riviera test scripts

### DIFF
--- a/test/pcie-hip/.gitignore
+++ b/test/pcie-hip/.gitignore
@@ -1,9 +1,16 @@
 gen/
-libraries/
 svpcie_sim_tb/
 svpcie_sim_tb.qsys
 svpcie_sim_tb.sopcinfo
-transcript
 altpcie_monitor_sv_dlhip_tlp_file_log.log
-vsim.wlf
 .*.sw?
+
+# ModelSim
+libraries/
+transcript
+vsim.wlf
+
+# Aldec
+compile/
+library.cfg
+dataset.asdb

--- a/test/pcie-hip/asim.do
+++ b/test/pcie-hip/asim.do
@@ -1,0 +1,94 @@
+# * vim: syntax=tcl
+
+set QSYS_SIMDIR gen/simulation/
+# The qsys test bench generates multiple altpcie_monitor_sv_dlhip_sim cores
+# all trying to write to the same log file, so output their data to the prompt
+# as well to make it usable.
+set USER_DEFINED_COMPILE_OPTIONS "+define+ALTPCIE_MONITOR_SV_HIP_DLTL_PROMPT"
+set USER_DEFINED_ELAB_OPTIONS ""
+set TOP_LEVEL_NAME tb
+
+# Keep signals in the testbench
+# *) the testbench
+append USER_DEFINED_ELAB_OPTIONS " +access +r +m+tb"
+# *) the qsys interconnect
+append USER_DEFINED_ELAB_OPTIONS " +access +r +p+/tb/svpcie"
+# *) the fejkon pcie ip cores
+append USER_DEFINED_ELAB_OPTIONS " +access +r +m+fejkon_pcie_data"
+append USER_DEFINED_ELAB_OPTIONS " +access +r +m+fejkon_pcie_avalon"
+append USER_DEFINED_ELAB_OPTIONS " +access +r +m+intel_pcie_tlp_adapter"
+# *) any altpcie monitor
+append USER_DEFINED_ELAB_OPTIONS " +access +r +m+altpcie_monitor_sv_dlhip_sim"
+# *) altpcied_sv_hwtcl
+append USER_DEFINED_ELAB_OPTIONS " +access +r +p+/tb/svpcie/root/g_bfm_top_rp/altpcietb_bfm_top_rp/g_bfm/genblk1/rp/inst/apps"
+# *) to read success of pcie setup
+append USER_DEFINED_ELAB_OPTIONS " +access +r +p+/tb/svpcie/root/g_bfm_top_rp/altpcietb_bfm_top_rp/g_bfm/genblk1/rp/inst/apps/g_root_port/genblk1/drvr/*"
+
+set compile_all ![file isdirectory "libraries"]
+
+source $QSYS_SIMDIR/aldec/rivierapro_setup.tcl
+
+if $compile_all {
+  dev_com
+  com
+} else {
+  # Only re-compile our internal IPs
+  vlog -sv gen/simulation/submodules/fejkon_pcie_data.sv -work fejkon_pcie_data
+  vlog -sv gen/simulation/submodules/fejkon_pcie_avalon.sv -work fejkon_pcie_avalon
+  vlog -sv gen/simulation/submodules/intel_pcie_tlp_adapter.sv -work intel_pcie_tlp_adapter
+}
+
+# The EDA space is not really know to make bugless software, it seems these
+# files are left out from the example designs.
+vlog gen/altpcierd_tl_cfg_sample.v
+vlog -sv gen/altpcied_sv_hwtcl.sv
+vlog gen/altpcierd_hip_rs.v
+vlog -sv tb.sv -l altera_common_sv_packages
+
+elab
+
+log -recursive /*
+
+if [expr {![batch_mode]}] {
+  do wave.do
+}
+
+# TODO: This does not seem to trigger:
+# # KERNEL:            114016601: INFO: tb.3unnblk: Test passed
+# # RUNTIME: Info: RUNTIME_0070 tb.sv (135): $stop called.
+# # KERNEL: Time: 114016601 ps,  Iteration: 0,  Instance: /tb,  Process: @INITIAL#66_5@.
+# # KERNEL: Stopped at time 114016601 ps + 0.
+# if [batch_mode] {
+#   if [expr {!$broken}] {
+#     puts "Failed: test reached deadline"
+#     exit -code 1
+#   }
+#   exit -code [expr [assertion count -fails -r /] > 0]
+# }
+# # Failed: test reached deadline
+set broken 0
+onbreak {
+ set broken 1
+ resume
+}
+
+run 150 us
+# TODO: This is ? in Riviera-PRO
+#if {[examine -expr {/tb/svpcie/root/g_bfm_top_rp/altpcietb_bfm_top_rp/g_bfm/genblk1/rp/inst/apps/g_root_port/genblk1/drvr/ebfm_log_stop_sim/success == 1}] != "true"} {
+#  echo "PCIe self-test failed"
+#  if [batch_mode] {
+#    exit -code 1
+#  }
+#} else {
+  echo "PCIe self-test complete"
+  # Run custom testing in tb.sv
+  run 100 us
+#}
+
+if [batch_mode] {
+  if [expr {!$broken}] {
+    puts "Failed: test reached deadline"
+    exit -code 1
+  }
+  exit -code [expr [assertion count -fails -r /] > 0]
+}

--- a/test/pcie-hip/awave.do
+++ b/test/pcie-hip/awave.do
@@ -1,0 +1,80 @@
+onerror { resume }
+set curr_transcript [transcript]
+transcript off
+
+add wave /tb/svpcie/endp0_clk_clk
+add wave /tb/svpcie/endp0_rx_st_data
+add wave /tb/svpcie/endp0_rx_st_empty
+add wave /tb/svpcie/endp0_rx_st_endofpacket
+add wave /tb/svpcie/endp0_rx_st_error
+add wave /tb/svpcie/endp0_rx_st_ready
+add wave /tb/svpcie/endp0_rx_st_startofpacket
+add wave /tb/svpcie/endp0_rx_st_valid
+add wave /tb/svpcie/fejkon_pcie_data/tlp_rx_frm_unsupported
+add wave /tb/svpcie/fejkon_pcie_data/tlp_rx_frm_type
+add wave /tb/svpcie/fejkon_pcie_data/tlp_rx_frm_masked_address
+add wave /tb/svpcie/fejkon_pcie_data/tlp_rx_frm_tag
+add wave /tb/svpcie/fejkon_pcie_data/tlp_rx_frm_requester_id
+add wave /tb/svpcie/intel_pcie_tlp_adapter_phy_tx_st_data
+add wave /tb/svpcie/intel_pcie_tlp_adapter_phy_tx_st_empty
+add wave /tb/svpcie/intel_pcie_tlp_adapter_phy_tx_st_endofpacket
+add wave /tb/svpcie/intel_pcie_tlp_adapter_phy_tx_st_error
+add wave /tb/svpcie/intel_pcie_tlp_adapter_phy_tx_st_ready
+add wave /tb/svpcie/intel_pcie_tlp_adapter_phy_tx_st_startofpacket
+add wave /tb/svpcie/intel_pcie_tlp_adapter_phy_tx_st_valid
+add wave /tb/svpcie/intel_pcie_tlp_adapter_tlp_rx_st_data
+add wave /tb/svpcie/intel_pcie_tlp_adapter_tlp_rx_st_empty
+add wave /tb/svpcie/intel_pcie_tlp_adapter_tlp_rx_st_endofpacket
+add wave /tb/svpcie/intel_pcie_tlp_adapter_tlp_rx_st_error
+add wave /tb/svpcie/intel_pcie_tlp_adapter_tlp_rx_st_ready
+add wave /tb/svpcie/intel_pcie_tlp_adapter_tlp_rx_st_startofpacket
+add wave /tb/svpcie/intel_pcie_tlp_adapter_tlp_rx_st_valid
+add wave /tb/svpcie/tlp_mux_out_channel
+add wave /tb/svpcie/tlp_mux_out_data
+add wave /tb/svpcie/tlp_mux_out_empty
+add wave /tb/svpcie/tlp_mux_out_endofpacket
+add wave /tb/svpcie/tlp_mux_out_ready
+add wave /tb/svpcie/tlp_mux_out_startofpacket
+add wave /tb/svpcie/tlp_mux_out_valid
+add wave /tb/svpcie/endp0_rx_bar_be_rx_st_bar
+add wave /tb/svpcie/endp0_tx_cred_tx_cons_cred_sel
+add wave /tb/svpcie/endp0_tx_cred_tx_cred_datafccp
+add wave /tb/svpcie/endp0_tx_cred_tx_cred_datafcnp
+add wave /tb/svpcie/endp0_tx_cred_tx_cred_datafcp
+add wave /tb/svpcie/endp0_tx_cred_tx_cred_fchipcons
+add wave /tb/svpcie/endp0_tx_cred_tx_cred_fcinfinite
+add wave /tb/svpcie/endp0_tx_cred_tx_cred_hdrfccp
+add wave /tb/svpcie/endp0_tx_cred_tx_cred_hdrfcnp
+add wave /tb/svpcie/endp0_tx_cred_tx_cred_hdrfcp
+add wave /tb/svpcie/fejkon_pcie_data_mem_access_req_data
+add wave /tb/svpcie/fejkon_pcie_data_mem_access_req_ready
+add wave /tb/svpcie/fejkon_pcie_data_mem_access_req_valid
+add wave /tb/svpcie/fejkon_pcie_avalon/mem_access_req_address
+add wave /tb/svpcie/fejkon_pcie_avalon_mem_access_resp_data
+add wave /tb/svpcie/fejkon_pcie_avalon_mem_access_resp_ready
+add wave /tb/svpcie/fejkon_pcie_avalon_mem_access_resp_valid
+add wave /tb/svpcie/fejkon_pcie_avalon_mm_address
+add wave /tb/svpcie/fejkon_pcie_avalon_mm_byteenable
+add wave /tb/svpcie/fejkon_pcie_avalon_mm_writedata
+add wave /tb/svpcie/fejkon_pcie_avalon_mm_read
+add wave /tb/svpcie/fejkon_pcie_avalon_mm_write
+add wave /tb/svpcie/fejkon_pcie_avalon_mm_readdatavalid
+add wave /tb/svpcie/fejkon_pcie_avalon_mm_waitrequest
+add wave /tb/svpcie/fejkon_pcie_avalon_mm_response
+add wave /tb/svpcie/fejkon_pcie_avalon_mm_readdata
+add wave /tb/svpcie/fejkon_pcie_avalon_mm_writeresponsevalid
+add wave /tb/svpcie/root/g_bfm_top_rp/altpcietb_bfm_top_rp/g_bfm/genblk1/rp/inst/apps_tx_st_valid
+add wave /tb/svpcie/root/g_bfm_top_rp/altpcietb_bfm_top_rp/g_bfm/genblk1/rp/inst/apps_tx_st_endofpacket
+add wave /tb/svpcie/root/g_bfm_top_rp/altpcietb_bfm_top_rp/g_bfm/genblk1/rp/inst/apps_tx_st_startofpacket
+add wave /tb/svpcie/root/g_bfm_top_rp/altpcietb_bfm_top_rp/g_bfm/genblk1/rp/inst/apps_tx_st_data
+add wave /tb/svpcie/root/g_bfm_top_rp/altpcietb_bfm_top_rp/g_bfm/genblk1/rp/inst/apps_tx_st_empty
+add wave /tb/svpcie/root/g_bfm_top_rp/altpcietb_bfm_top_rp/g_bfm/genblk1/rp/inst/dut_rx_st_data
+add wave /tb/svpcie/root/g_bfm_top_rp/altpcietb_bfm_top_rp/g_bfm/genblk1/rp/inst/dut_rx_st_endofpacket
+add wave /tb/svpcie/root/g_bfm_top_rp/altpcietb_bfm_top_rp/g_bfm/genblk1/rp/inst/dut_rx_st_startofpacket
+add wave /tb/svpcie/root/g_bfm_top_rp/altpcietb_bfm_top_rp/g_bfm/genblk1/rp/inst/dut_rx_st_valid
+add wave /tb/svpcie/root/g_bfm_top_rp/altpcietb_bfm_top_rp/g_bfm/genblk1/rp/inst/dut_rx_st_empty
+wv.cursors.add -time 91900ns -name {Default cursor}
+wv.cursors.setactive -name {Default cursor}
+wv.zoom.range -from 30400ns -to 130216010ps
+wv.time.unit.auto.set
+transcript $curr_transcript


### PR DESCRIPTION
Scripts to run the PCIe test on Riviera-PRO.

For xcvr there is more work as a lot of files are marked ModelSim specific.